### PR TITLE
Add Embeddings.quantize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "accelerate-src"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415ed64958754dbe991900f3940677e6a7eefb4d7367afd70d642677b0c7d19d"
+
+[[package]]
+name = "anyhow"
+version = "1.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e1f47f7dc0422027a4e370dd4548d4d66b26782e513e98dca1e689e058a80e"
+
+[[package]]
 name = "approx"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +22,12 @@ checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "arc-swap"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
 
 [[package]]
 name = "autocfg"
@@ -30,6 +48,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "cauchy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff11ddd2af3b5e80dd0297fee6e56ac038d9bdc549573cdb51bd6d2efe7f05e"
+dependencies = [
+ "num-complex",
+ "num-traits",
+ "rand",
+ "serde",
+]
+
+[[package]]
+name = "cblas-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6feecd82cce51b0204cf063f0041d69f24ce83f680d87514b004248e7b0fa65"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +79,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "crossbeam-channel"
@@ -86,6 +131,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "dirs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+dependencies = [
+ "cfg-if 0.1.10",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,7 +173,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "finalfusion"
 version = "0.16.0"
-source = "git+https://github.com/finalfusion/finalfusion-rust#e02fd622fc35c221256de561b13a11034a7e3bd5"
+source = "git+https://github.com/finalfusion/finalfusion-rust#a652bc25a0acae82a8cb7c3a378830514d8abccd"
 dependencies = [
  "byteorder",
  "fnv",
@@ -128,6 +207,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hermit-abi"
@@ -171,6 +256,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "intel-mkl-src"
+version = "0.6.0+mkl2020.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5682f8876cc7087e9bb4f2038618e04cb27629325d58caeca7ef3b8039ea5827"
+dependencies = [
+ "anyhow",
+ "intel-mkl-tool",
+]
+
+[[package]]
+name = "intel-mkl-tool"
+version = "0.2.0+mkl2020.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1c33e6eafc56431ed3d8317c35fa9148c4c407c6a8c67f3fd946840d758ef0"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "dirs",
+ "glob",
+ "pkg-config",
+]
+
+[[package]]
 name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +294,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "lapack"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a7f0050af10913bc5e4f6091df38870cb5d4e45094d3dd551c1aff9d1d59b26"
+dependencies = [
+ "lapack-sys",
+ "libc",
+ "num-complex",
+]
+
+[[package]]
+name = "lapack-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d3a8a9f07310243de6c6226f039f14bce8d2f4c96b5d30ddbcfa31eb4e94ad"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "lax"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e49ff5bbaf07352b492b17aab73a86871f0c6029f427035fd0562cd0df573c8a"
+dependencies = [
+ "cauchy",
+ "lapack",
+ "num-traits",
+ "thiserror",
 ]
 
 [[package]]
@@ -258,6 +398,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec23e6762830658d2b3d385a75aa212af2f67a4586d4442907144f3bb6a1ca8"
 dependencies = [
  "approx",
+ "cblas-sys",
+ "libc",
  "matrixmultiply",
  "num-complex",
  "num-integer",
@@ -267,12 +409,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray-linalg"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6953b6c18697bc401c596b885350ea56a696da46415a10a6ed22f2a2e3d78d74"
+dependencies = [
+ "cauchy",
+ "lax",
+ "ndarray",
+ "num-complex",
+ "num-traits",
+ "rand",
+ "thiserror",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
 dependencies = [
  "num-traits",
+ "rand",
+ "serde",
 ]
 
 [[package]]
@@ -378,6 +537,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +586,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf9e4d128bfbddc898ad3409900080d8d5095c379632fbbfbb9c8cfb1fb852b"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "pyo3-log"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d43bb6bf4460e400696a4c8b4b647362e1eddc4ac31b993998692e4c2a9a5f"
+dependencies = [
+ "arc-swap",
+ "log",
+ "pyo3",
 ]
 
 [[package]]
@@ -545,13 +721,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "reductive"
-version = "0.7.0"
+name = "redox_users"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e477ad04a955c6f8a1b5592ee6b94d93b626a506c915201bfc085c5b71706a7"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
+ "getrandom",
+ "redox_syscall",
+]
+
+[[package]]
+name = "reductive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd80fc9c2b940bd2bde02616bc1f95695f0b737bc3ca00775fd91a6952e6049f"
+dependencies = [
+ "lax",
  "log",
  "ndarray",
+ "ndarray-linalg",
  "num-traits",
  "ordered-float",
  "rand",
@@ -562,10 +750,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
@@ -597,11 +800,16 @@ checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 name = "snakefusion"
 version = "0.1.0"
 dependencies = [
+ "accelerate-src",
+ "anyhow",
  "finalfusion",
+ "intel-mkl-src",
  "itertools 0.8.2",
  "ndarray",
  "numpy",
  "pyo3",
+ "pyo3-log",
+ "reductive",
  "toml",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,28 @@ itertools = "0.8"
 finalfusion = { git = "https://github.com/finalfusion/finalfusion-rust" }
 ndarray = "0.15"
 numpy = "0.15"
+pyo3-log = "0.5"
+reductive = "0.8.1"
 toml = "0.5"
+
+# Fix incompatibility between anyhow and intel-mkl tool. Remove with
+# the next release of intel-mkl too. For more information, see:
+# https://github.com/rust-math/intel-mkl-src/issues/68
+anyhow = { version = "<=1.0.48", optional = true }
+
+[dependencies.accelerate-src]
+version = "0.3"
+optional = true
+
+[dependencies.intel-mkl-src]
+version = "0.6"
+optional = true
+default-features = false
+
+[features]
+accelerate = ["opq", "ndarray/blas", "accelerate-src"]
+intel-mkl = ["opq", "ndarray/blas", "intel-mkl-src/mkl-static-lp64-seq", "anyhow"]
+opq = ["reductive/opq-train"]
 
 [package.metadata.maturin]
 requires-dist = ["numpy"]

--- a/snakefusion/tests/test_quantization.py
+++ b/snakefusion/tests/test_quantization.py
@@ -1,0 +1,38 @@
+import numpy
+import pytest
+
+import snakefusion
+
+
+def test_quantization(analogy_fifu):
+    quantized = analogy_fifu.quantize(50, n_subquantizer_bits=5)
+    for embed in analogy_fifu:
+        assert numpy.allclose(quantized[embed.word], embed.embedding, atol=0.1)
+
+
+@pytest.mark.skipif(
+    snakefusion.Config.OPQ, reason="snakefusion is compiled with OPQ support"
+)
+def test_quantization_opq_fails_without_opq(analogy_fifu):
+    with pytest.raises(ValueError, match="Unsupported quantizer"):
+        analogy_fifu.quantize(50, quantizer="opq", n_subquantizer_bits=5)
+
+    with pytest.raises(ValueError, match="Unsupported quantizer"):
+        analogy_fifu.quantize(50, quantizer="gaussian_opq", n_subquantizer_bits=5)
+
+
+@pytest.mark.skipif(
+    not snakefusion.Config.OPQ, reason="snakefusion is not compiled with OPQ support"
+)
+def test_opq_quantization(analogy_fifu):
+    opq_quantized = analogy_fifu.quantize(50, quantizer="opq", n_subquantizer_bits=5)
+    for embed in analogy_fifu:
+        assert numpy.allclose(opq_quantized[embed.word], embed.embedding, atol=0.1)
+
+    gaussian_opq_quantized = analogy_fifu.quantize(
+        50, quantizer="gaussian_opq", n_subquantizer_bits=5
+    )
+    for embed in analogy_fifu:
+        assert numpy.allclose(
+            gaussian_opq_quantized[embed.word], embed.embedding, atol=0.1
+        )

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,10 @@
+use pyo3::prelude::*;
+
+#[pyclass(name = "Config")]
+pub struct PyConfig;
+
+#[pymethods]
+impl PyConfig {
+    #[classattr]
+    pub const OPQ: bool = cfg!(feature = "opq");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,13 @@
+#[cfg(feature = "accelerate")]
+extern crate accelerate_src;
+
+#[cfg(feature = "intel-mkl")]
+extern crate intel_mkl_src;
+
 use pyo3::prelude::*;
+
+mod config;
+use config::PyConfig;
 
 mod embeddings;
 use embeddings::PyEmbeddings;
@@ -8,6 +17,9 @@ use embeddings_wrap::EmbeddingsWrap;
 
 mod iter;
 use iter::{PyEmbedding, PyEmbeddingIterator};
+
+mod pq;
+use pq::PyQuantizer;
 
 mod similarity;
 use similarity::PyWordSimilarity;
@@ -24,8 +36,11 @@ use storage::PyStorage;
 /// subwords, memory-mapped matrices, and quantized matrices.
 #[pymodule]
 fn snakefusion(_py: Python, m: &PyModule) -> PyResult<()> {
+    pyo3_log::init();
+    m.add_class::<PyConfig>()?;
     m.add_class::<PyEmbeddings>()?;
     m.add_class::<PyEmbedding>()?;
+    m.add_class::<PyQuantizer>()?;
     m.add_class::<PyStorage>()?;
     m.add_class::<PyWordSimilarity>()?;
     m.add_class::<PyVocab>()?;

--- a/src/pq.rs
+++ b/src/pq.rs
@@ -1,0 +1,16 @@
+use pyo3::prelude::*;
+
+#[pyclass(name = "Quantizer")]
+pub struct PyQuantizer;
+
+#[pymethods]
+impl PyQuantizer {
+    #[classattr]
+    const PQ: usize = 0;
+
+    #[classattr]
+    const OPQ: usize = 1;
+
+    #[classattr]
+    const GAUSSIAN_OPQ: usize = 2;
+}


### PR DESCRIPTION
This method can be used to quantize the embedding matrix. The `opq` and `gaussian_opq` quantization methods are only available if the package is compiled with the `accelerate` or `intel-mkl` feature.