### PR TITLE
Add Embeddings::{from,to}_bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,9 +172,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "finalfusion"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7902d4ede42ac491256f09c922157a6e9d5535b5b53289690715357799c1d344"
+checksum = "896a994a7a86ff88f0c1b449d8f4c0cd836b83d172836d2d9ce90e9e7a3cd80b"
 dependencies = [
  "byteorder",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ features = ["extension-module", "abi3", "abi3-py36"]
 
 [dependencies]
 itertools = "0.10"
-finalfusion = "0.17.1"
+finalfusion = "0.17.2"
 ndarray = "0.15"
 numpy = "0.15"
 pyo3-log = "0.5"


### PR DESCRIPTION
These methods can be used to (de)serialize embeddings from and to Python `bytes`.